### PR TITLE
[WIP] Feature: Minced values for key

### DIFF
--- a/Source/NSObject+HYPMinced.h
+++ b/Source/NSObject+HYPMinced.h
@@ -11,4 +11,6 @@
 - (NSDictionary *)minced_JSONObjectKeys;
 - (NSDictionary *)minced_JSONObjectKeysWithNonnulls;
 
+- (id)minced_valuesForKey:(NSString *)key;
+
 @end

--- a/Source/NSObject+HYPMinced.m
+++ b/Source/NSObject+HYPMinced.m
@@ -30,6 +30,10 @@
     return [self minced_JSONObjectKeysWithNonnulls:YES];
 }
 
+- (id)minced_valuesForKey:(NSString *)key {
+    return nil;
+}
+
 #pragma mark - Private
 
 - (id)minced_JSONKeysWithNonnullValues:(BOOL)unnullify {

--- a/Tests/Tests/Tests.m
+++ b/Tests/Tests/Tests.m
@@ -27,4 +27,8 @@
     XCTAssertEqualObjects([nullSnakeCaseJSON minced_JSONKeysWithNonnulls], nonnullCamelCaseJSON);
 }
 
+- (void)testMincedValuesForKey {
+    
+}
+
 @end


### PR DESCRIPTION
``` objc
// Converts numbers to strings
+- (id)minced_valuesForKey:(NSString *)key;
```
## Before

``` JSON
[
  {
    "id":3
  },
  {
    "id":"4"
  }
]
```
## After

``` objc
id mincedJSON = [JSON minced_valuesForKey:@"id"];
```

``` JSON
[
  {
    "id":"3"
  },
  {
    "id":"4"
  }
]
```
